### PR TITLE
[WIP] Refactor various parts of qiskit using multiple dispatch

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -35,6 +35,7 @@ import copy
 from itertools import zip_longest
 
 import numpy
+import plum
 
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.quantumregister import QuantumRegister
@@ -46,7 +47,7 @@ from .tools import pi_check
 _CUTOFF_PRECISION = 1E-10
 
 
-class Instruction:
+class Instruction(metaclass=plum.Referentiable):
     """Generic quantum instruction."""
 
     def __init__(self, name, num_qubits, num_clbits, params, duration=None, unit='dt'):

--- a/qiskit/circuit/library/blueprintcircuit.py
+++ b/qiskit/circuit/library/blueprintcircuit.py
@@ -13,7 +13,7 @@
 """Blueprint circuit object."""
 
 from typing import Optional
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.parametertable import ParameterTable
 
@@ -41,7 +41,7 @@ class BlueprintCircuit(QuantumCircuit):
         self._cregs = []
         self._qubits = []
 
-    @abstractmethod
+
     def _check_configuration(self, raise_on_failure: bool = True) -> bool:
         """Check if the current configuration allows the circuit to be built.
 

--- a/qiskit/circuit/library/blueprintcircuit.py
+++ b/qiskit/circuit/library/blueprintcircuit.py
@@ -18,7 +18,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.parametertable import ParameterTable
 
 
-class BlueprintCircuit(QuantumCircuit, ABC):
+class BlueprintCircuit(QuantumCircuit):
     """Blueprint circuit object.
 
     In many applications it is necessary to pass around the structure a circuit will have without

--- a/qiskit/circuit/parametervector.py
+++ b/qiskit/circuit/parametervector.py
@@ -14,8 +14,7 @@
 
 from .parameter import Parameter
 
-
-class ParameterVector:
+class ParameterVector():
     """ParameterVector class to quickly generate lists of parameters."""
 
     def __init__(self, name, length=0):

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -52,8 +52,14 @@ try:
 except Exception:  # pylint: disable=broad-except
     HAS_PYGMENTS = False
 
+import plum
+from plum import Dispatcher, Self, dispatch
+import abc
 
-class QuantumCircuit:
+
+class QuantumCircuit(metaclass=plum.Referentiable(abc.ABCMeta)):
+
+    dispatch = Dispatcher(in_class=Self)
     """Create a new circuit.
 
     A circuit is a list of instructions bound to some registers.
@@ -299,7 +305,9 @@ class QuantumCircuit:
         """Return the prefix to use for auto naming."""
         return cls.prefix
 
-    def has_register(self, register):
+
+    @dispatch
+    def has_register(self, register: QuantumRegister):
         """
         Test if this circuit has the register r.
 
@@ -309,14 +317,30 @@ class QuantumCircuit:
         Returns:
             bool: True if the register is contained in this circuit.
         """
-        has_reg = False
-        if (isinstance(register, QuantumRegister) and
-                register in self.qregs):
-            has_reg = True
-        elif (isinstance(register, ClassicalRegister) and
-              register in self.cregs):
-            has_reg = True
-        return has_reg
+        return register in self.qregs
+
+    @dispatch
+    def has_register(self, register: ClassicalRegister):
+        return register in self.cregs
+
+    # def has_register(self, register):
+    #     """
+    #     Test if this circuit has the register r.
+
+    #     Args:
+    #         register (Register): a quantum or classical register.
+
+    #     Returns:
+    #         bool: True if the register is contained in this circuit.
+    #     """
+    #     has_reg = False
+    #     if (isinstance(register, QuantumRegister) and
+    #             register in self.qregs):
+    #         has_reg = True
+    #     elif (isinstance(register, ClassicalRegister) and
+    #           register in self.cregs):
+    #         has_reg = True
+    #     return has_reg
 
     def reverse_ops(self):
         """Reverse the circuit by reversing the order of instructions.

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -323,25 +323,6 @@ class QuantumCircuit(metaclass=plum.Referentiable(abc.ABCMeta)):
     def has_register(self, register: ClassicalRegister):
         return register in self.cregs
 
-    # def has_register(self, register):
-    #     """
-    #     Test if this circuit has the register r.
-
-    #     Args:
-    #         register (Register): a quantum or classical register.
-
-    #     Returns:
-    #         bool: True if the register is contained in this circuit.
-    #     """
-    #     has_reg = False
-    #     if (isinstance(register, QuantumRegister) and
-    #             register in self.qregs):
-    #         has_reg = True
-    #     elif (isinstance(register, ClassicalRegister) and
-    #           register in self.cregs):
-    #         has_reg = True
-    #     return has_reg
-
     def reverse_ops(self):
         """Reverse the circuit by reversing the order of instructions.
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -56,6 +56,8 @@ import plum
 from plum import Dispatcher, Self, dispatch
 import abc
 
+# a bit faster to do this once
+NoneType = type(None)
 
 class QuantumCircuit(metaclass=plum.Referentiable(abc.ABCMeta)):
 
@@ -272,20 +274,27 @@ class QuantumCircuit(metaclass=plum.Referentiable(abc.ABCMeta)):
         """
         return self._metadata
 
+    # Alternative; omit this method and get a method lookup error.
+    # Omitting would be more useful if the dispatcher prints the nearest matches.
     @metadata.setter
+    @dispatch
     def metadata(self, metadata):
+        raise TypeError("Only a dictionary or None is accepted for circuit metadata")
+
+    @metadata.setter
+    @dispatch
+    def metadata(self, metadata: {dict, NoneType}):
         """Update the circuit metadata"""
-        if not isinstance(metadata, dict) and metadata is not None:
-            raise TypeError("Only a dictionary or None is accepted for circuit metadata")
         self._metadata = metadata
 
     def __str__(self):
         return str(self.draw(output='text'))
 
-    def __eq__(self, other):
-        if not isinstance(other, QuantumCircuit):
-            return False
+    @dispatch
+    def __eq__(self, other): return False
 
+    @dispatch
+    def __eq__(self, other: Self):
         # TODO: remove the DAG from this function
         from qiskit.converters import circuit_to_dag
         return circuit_to_dag(self) == circuit_to_dag(other)

--- a/qiskit/opflow/converters/converter_base.py
+++ b/qiskit/opflow/converters/converter_base.py
@@ -12,12 +12,14 @@
 
 """ ConverterBase Class """
 
+from plum import Referentiable
+import abc
 from abc import ABC, abstractmethod
 
 from ..operator_base import OperatorBase
 
 
-class ConverterBase(ABC):
+class ConverterBase(metaclass=Referentiable(abc.ABCMeta)):
     r"""
     Converters take an Operator and return a new Operator, generally isomorphic
     in some way with the first, but with certain desired properties. For example,

--- a/qiskit/opflow/gradients/derivative_utils.py
+++ b/qiskit/opflow/gradients/derivative_utils.py
@@ -1,0 +1,16 @@
+from multipledispatch import dispatch
+from qiskit.circuit import ParameterExpression
+
+# An opflow expression representing 0.0 (that evaluates to zero)
+#ZERO_EXPR = ~Zero @ One
+ZERO_EXPR = 0.0
+
+@dispatch(float, (float, int))
+def is_coeff_c(coeff, c):
+    return coeff == c
+
+@dispatch(ParameterExpression, (float, int))
+def is_coeff_c(coeff, c):
+    return coeff._symbol_expr == c
+#    return coeff == c
+

--- a/qiskit/opflow/gradients/derivative_utils.py
+++ b/qiskit/opflow/gradients/derivative_utils.py
@@ -1,16 +1,14 @@
-from multipledispatch import dispatch
+from plum import dispatch
 from qiskit.circuit import ParameterExpression
 
 # An opflow expression representing 0.0 (that evaluates to zero)
 #ZERO_EXPR = ~Zero @ One
 ZERO_EXPR = 0.0
 
-@dispatch(float, (float, int))
-def is_coeff_c(coeff, c):
+@dispatch
+def is_coeff_c(coeff: float, c: {float, int}):
     return coeff == c
 
-@dispatch(ParameterExpression, (float, int))
-def is_coeff_c(coeff, c):
+@dispatch
+def is_coeff_c(coeff: ParameterExpression, c: {float, int}):
     return coeff._symbol_expr == c
-#    return coeff == c
-

--- a/qiskit/quantum_info/operators/mixins/linear.py
+++ b/qiskit/quantum_info/operators/mixins/linear.py
@@ -39,11 +39,11 @@ class LinearMixin(MultiplyMixin, ABC):
 
     def __add__(self, other):
         qargs = getattr(other, 'qargs', None)
-        return self._add(other, qargs=qargs)
+        return self._add(other, qargs)
 
     def __sub__(self, other):
         qargs = getattr(other, 'qargs', None)
-        return self._add(-other, qargs=qargs)
+        return self._add(-other, qargs)
 
     @abstractmethod
     def _add(self, other, qargs=None):

--- a/qiskit/quantum_info/operators/mixins/tolerances.py
+++ b/qiskit/quantum_info/operators/mixins/tolerances.py
@@ -14,6 +14,7 @@
 Tolerances mixin class.
 """
 
+import plum
 from abc import ABCMeta
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators.predicates import ATOL_DEFAULT, RTOL_DEFAULT
@@ -59,7 +60,13 @@ class TolerancesMeta(ABCMeta):
         cls._RTOL_DEFAULT = value
 
 
-class TolerancesMixin(metaclass=TolerancesMeta):
+# We need an ancestor of the class that uses `Self` (in this case ScalarOp)
+# to have metaclass Referentiable. The inheritance is a bit complicated,
+# so finding where to put it to avoid metaclass conflicts is not obvious
+# This is not a very pretty solution. It will likely break when we need
+# to make Referentiable a class that does not depend on TolerancesMixin.
+# class TolerancesMixin(metaclass=TolerancesMeta):
+class TolerancesMixin(metaclass=plum.Referentiable(TolerancesMeta)):
     """Mixin Class for tolerances"""
 
     @property

--- a/qiskit/quantum_info/operators/random.py
+++ b/qiskit/quantum_info/operators/random.py
@@ -29,25 +29,7 @@ from .symplectic.random import random_pauli_table
 from .symplectic.random import random_stabilizer_table
 
 DEFAULT_RNG = default_rng()
-
-
-# TODO: This probably works, but all the calls have to change
-# from seed=seed to seed.
-# @dispatch
-# def random_unitary(dims): return random_unitary(dims, DEFAULT_RNG)
-
-# @dispatch
-# def random_unitary(dims, seed): return random_unitary(dims, default_rng(seed))
-
-# @dispatch
-# def random_unitary(dims, random_state: np.random.Generator):
-#     """Doc goes here
-#     """
-#     dim = np.product(dims)
-#     from scipy import stats
-#     mat = stats.unitary_group.rvs(dim, random_state=random_state)
-#     return Operator(mat, input_dims=dims, output_dims=dims)
-
+NoneType = type(None)
 
 def random_unitary(dims, seed=None):
     """Return a random unitary Operator.
@@ -62,18 +44,20 @@ def random_unitary(dims, seed=None):
     Returns:
         Operator: a unitary operator.
     """
-    if seed is None:
-        random_state = DEFAULT_RNG
-    elif isinstance(seed, np.random.Generator):
-        random_state = seed
-    else:
-        random_state = default_rng(seed)
+    return _random_unitary(dims, seed)
 
+@dispatch
+def _random_unitary(dims, seed: NoneType): return random_unitary(dims, DEFAULT_RNG)
+
+@dispatch
+def _random_unitary(dims, seed): return random_unitary(dims, default_rng(seed))
+
+@dispatch
+def _random_unitary(dims, random_state: np.random.Generator):
     dim = np.product(dims)
     from scipy import stats
     mat = stats.unitary_group.rvs(dim, random_state=random_state)
     return Operator(mat, input_dims=dims, output_dims=dims)
-
 
 def random_hermitian(dims, traceless=False, seed=None):
     """Return a random hermitian Operator.

--- a/qiskit/quantum_info/operators/random.py
+++ b/qiskit/quantum_info/operators/random.py
@@ -17,6 +17,8 @@ Methods to create random operators.
 import numpy as np
 from numpy.random import default_rng
 
+from plum import dispatch
+
 from qiskit.quantum_info.operators import Operator, Stinespring
 from qiskit.exceptions import QiskitError
 
@@ -27,6 +29,24 @@ from .symplectic.random import random_pauli_table
 from .symplectic.random import random_stabilizer_table
 
 DEFAULT_RNG = default_rng()
+
+
+# TODO: This probably works, but all the calls have to change
+# from seed=seed to seed.
+# @dispatch
+# def random_unitary(dims): return random_unitary(dims, DEFAULT_RNG)
+
+# @dispatch
+# def random_unitary(dims, seed): return random_unitary(dims, default_rng(seed))
+
+# @dispatch
+# def random_unitary(dims, random_state: np.random.Generator):
+#     """Doc goes here
+#     """
+#     dim = np.product(dims)
+#     from scipy import stats
+#     mat = stats.unitary_group.rvs(dim, random_state=random_state)
+#     return Operator(mat, input_dims=dims, output_dims=dims)
 
 
 def random_unitary(dims, seed=None):

--- a/qiskit/quantum_info/operators/scalar_op.py
+++ b/qiskit/quantum_info/operators/scalar_op.py
@@ -177,7 +177,13 @@ class ScalarOp(LinearOp):
     def expand(self, other): return self.expand(Operator(other))
 
 
-    def _add(self, other, qargs=None):
+    @dispatch
+    def _add(self, other):
+        qargs = getattr(other, 'qargs', None)
+        return self._add(other, qargs)
+
+    @dispatch
+    def _add(self, other, qargs):
         """Return the operator self + other.
 
         If ``qargs`` are specified the other operator will be added
@@ -195,8 +201,8 @@ class ScalarOp(LinearOp):
         Raises:
             QiskitError: if other has incompatible dimensions.
         """
-        if qargs is None:
-            qargs = getattr(other, 'qargs', None)
+        # if qargs is None:
+        #     qargs = getattr(other, 'qargs', None)
 
         if not isinstance(other, BaseOperator):
             other = Operator(other)

--- a/qiskit/quantum_info/operators/scalar_op.py
+++ b/qiskit/quantum_info/operators/scalar_op.py
@@ -49,6 +49,7 @@ class ScalarOp(LinearOp):
         Raises:
             QiskitError: If the optional coefficient is invalid.
         """
+
         if not isinstance(coeff, Number):
             QiskitError("coeff {} must be a number.".format(coeff))
         self._coeff = coeff
@@ -239,7 +240,8 @@ class ScalarOp(LinearOp):
         return ret
 
     @staticmethod
-    def _pad_with_identity(current, other, qargs=None):
+    @dispatch
+    def _pad_with_identity(current, other, qargs):
         """Pad another operator with identities.
 
         Args:
@@ -250,9 +252,11 @@ class ScalarOp(LinearOp):
         Returns:
             BaseOperator: the padded operator.
         """
-        if qargs is None:
-            return other
         return ScalarOp(current.input_dims()).compose(other, qargs=qargs)
+
+    @staticmethod
+    @dispatch
+    def _pad_with_identity(current, other): return other
 
 
 # Update docstrings for API docs

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -343,7 +343,7 @@ class QuantumState:  #(metaclass=plum.Referentiable(abc.ABCMeta)):
         # diagonal matrix multiplication
         ret = self.evolve(
             Operator(np.diag(proj), input_dims=dims, output_dims=dims),
-            qargs=qargs)
+            qargs)
 
         return outcome, ret
 
@@ -527,7 +527,7 @@ class QuantumState:  #(metaclass=plum.Referentiable(abc.ABCMeta)):
     def __matmul__(self, other):
         # Check for subsystem case return by __call__ method
         if isinstance(other, tuple) and len(other) == 2:
-            return self.evolve(other[0], qargs=other[1])
+            return self.evolve(other[0], other[1])
         return self.evolve(other)
 
     def __xor__(self, other):

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -15,16 +15,21 @@ Abstract QuantumState class.
 """
 
 import copy
+import abc
 from abc import abstractmethod
+import plum
+from plum import Dispatcher, Self, dispatch
 
 import numpy as np
 
 from qiskit.quantum_info.operators.operator import Operator
 from qiskit.result.counts import Counts
 
-
-class QuantumState:
+                     # TODO: sort out this metaclass mess
+class QuantumState:  #(metaclass=plum.Referentiable(abc.ABCMeta)):
     """Abstract quantum state base class"""
+
+    dispatch = plum.Dispatcher(in_class=Self)
 
     def __init__(self, op_shape=None):
         """Initialize a QuantumState object.
@@ -71,14 +76,17 @@ class QuantumState:
         """Make a copy of current operator."""
         return copy.deepcopy(self)
 
-    def seed(self, value=None):
-        """Set the seed for the quantum state RNG."""
-        if value is None:
-            self._rng_generator = None
-        elif isinstance(value, np.random.Generator):
-            self._rng_generator = value
-        else:
-            self._rng_generator = np.random.default_rng(value)
+    @dispatch
+    def seed(self):
+        self._rng_generator = None
+
+    @dispatch
+    def seed(self, value: np.random.Generator):
+        self._rng_generator = value
+
+    @dispatch
+    def seed(self, value):
+        self._rng_generator = np.random.default_rng(value)
 
     @abstractmethod
     def is_valid(self, atol=None, rtol=None):

--- a/qiskit/transpiler/layout.py
+++ b/qiskit/transpiler/layout.py
@@ -22,9 +22,12 @@ from qiskit.circuit.quantumregister import Qubit
 from qiskit.transpiler.exceptions import LayoutError
 from qiskit.converters import isinstanceint
 
+from plum import Referentiable, Self, Dispatcher
 
-class Layout():
+class Layout(metaclass=Referentiable):
     """Two-ways dict to represent a Layout."""
+
+    dispatch = Dispatcher(in_class=Self)
 
     def __init__(self, input_dict=None):
         """construct a Layout from a bijective dictionary, mapping
@@ -115,16 +118,31 @@ class Layout():
         if virtual is not None:
             self._v2p[virtual] = physical
 
+    @dispatch
+    def __delitem__(self, key: int):
+        del self._p2v[key]
+        del self._v2p[self._p2v[key]]
+
+    @dispatch
+    def __delitem__(self, key: Qubit):
+        del self._p2v[key]
+        del self._v2p[self._p2v[key]]
+
+    @dispatch
     def __delitem__(self, key):
-        if isinstance(key, int):
-            del self._p2v[key]
-            del self._v2p[self._p2v[key]]
-        elif isinstance(key, Qubit):
-            del self._v2p[key]
-            del self._p2v[self._v2p[key]]
-        else:
-            raise LayoutError('The key to remove should be of the form'
-                              ' Qubit or integer) and %s was provided' % (type(key),))
+        raise LayoutError('The key to remove should be of the form'
+                          ' Qubit or integer) and %s was provided' % (type(key),))
+
+    # def __delitem__(self, key):
+    #     if isinstance(key, int):
+    #         del self._p2v[key]
+    #         del self._v2p[self._p2v[key]]
+    #     elif isinstance(key, Qubit):
+    #         del self._v2p[key]
+    #         del self._p2v[self._v2p[key]]
+    #     else:
+    #         raise LayoutError('The key to remove should be of the form'
+    #                           ' Qubit or integer) and %s was provided' % (type(key),))
 
     def __len__(self):
         return len(self._p2v)

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -251,17 +251,17 @@ class TestStatevector(QiskitTestCase):
             op = op0
             op_full = Operator(np.eye(4)).tensor(op)
             target = Statevector(np.dot(op_full.data, vec))
-            self.assertEqual(state.evolve(op, qargs=[0]), target)
+            self.assertEqual(state.evolve(op, [0]), target)
 
             # Evolve on qubit 1
             op_full = Operator(np.eye(2)).tensor(op).tensor(np.eye(2))
             target = Statevector(np.dot(op_full.data, vec))
-            self.assertEqual(state.evolve(op, qargs=[1]), target)
+            self.assertEqual(state.evolve(op, [1]), target)
 
             # Evolve on qubit 2
             op_full = op.tensor(np.eye(4))
             target = Statevector(np.dot(op_full.data, vec))
-            self.assertEqual(state.evolve(op, qargs=[2]), target)
+            self.assertEqual(state.evolve(op, [2]), target)
 
             # Test evolve on 2-qubits
             op = op1.tensor(op0)
@@ -269,12 +269,12 @@ class TestStatevector(QiskitTestCase):
             # Evolve on qubits [0, 2]
             op_full = op1.tensor(np.eye(2)).tensor(op0)
             target = Statevector(np.dot(op_full.data, vec))
-            self.assertEqual(state.evolve(op, qargs=[0, 2]), target)
+            self.assertEqual(state.evolve(op, [0, 2]), target)
 
             # Evolve on qubits [2, 0]
             op_full = op0.tensor(np.eye(2)).tensor(op1)
             target = Statevector(np.dot(op_full.data, vec))
-            self.assertEqual(state.evolve(op, qargs=[2, 0]), target)
+            self.assertEqual(state.evolve(op, [2, 0]), target)
 
             # Test evolve on 3-qubits
             op = op2.tensor(op1).tensor(op0)
@@ -282,12 +282,12 @@ class TestStatevector(QiskitTestCase):
             # Evolve on qubits [0, 1, 2]
             op_full = op
             target = Statevector(np.dot(op_full.data, vec))
-            self.assertEqual(state.evolve(op, qargs=[0, 1, 2]), target)
+            self.assertEqual(state.evolve(op, [0, 1, 2]), target)
 
             # Evolve on qubits [2, 1, 0]
             op_full = op0.tensor(op1).tensor(op2)
             target = Statevector(np.dot(op_full.data, vec))
-            self.assertEqual(state.evolve(op, qargs=[2, 1, 0]), target)
+            self.assertEqual(state.evolve(op, [2, 1, 0]), target)
 
     def test_evolve_global_phase(self):
         """Test evolve circuit with global phase."""
@@ -296,7 +296,7 @@ class TestStatevector(QiskitTestCase):
         phase = np.pi / 4
         circ = QuantumCircuit(qr, global_phase=phase)
         circ.x(0)
-        state_f = state_i.evolve(circ, qargs=[0])
+        state_f = state_i.evolve(circ, [0])
         target = Statevector([0, 1]) * np.exp(1j * phase)
         self.assertEqual(state_f, target)
 


### PR DESCRIPTION
This PR refactors some code using multiple dispatch. This is an experiment in applying multiple dispatch in
various situations. The experiments are mostly spread sparsely across the repo. This comment is a WIP, as well.

This PR requires the *master* branch of [plum-dispatch](https://github.com/wesselb/plum). You can get this by cloning
plum-dispatch and doing, for example in a virtual env,  `pip install -e .`.

### Advantages/Motivation

* disentangles forests of  `isinstance` conditionals, making the logic more clear.
* Remove type-checking boilerplate. A method error is thrown if no matching method exists. For example
```python
        if not isinstance(scalar, (int, float, complex, ParameterExpression)):
            raise ValueError('Operators can only be scalar multiplied by float or complex, not '
```
* Especially useful with mathematical operators. This is by far the [heaviest use case in Julia](https://en.wikipedia.org/wiki/Multiple_dispatch#Use_in_practice). This is difficult in python because operators must be class methods that privilege one operand. A workaround is to use function calls rather than infix operators.
    * Or, one could have `__mul__` and `__rmul__` for several classes all call a function (not method) `multiple` which supports multiple dispatch. 

* types representing lists and tuples of homogeneous type simplify logic. An example (not in this PR) is
https://github.com/jlapeyre/qiskit-terra/blob/253339278eb4e706805ae57653524f67dc8ad6f3/qiskit/opflow/gradients/circuit_gradients/lin_comb.py#L142-L144

    is replaced by something like
```python
def func(params: {tuple, plum.List(tuple)}):
```
* Currently used mostly *within* classes in an asymmetric situation. I.e. with gradients the class is doing something to the argument. A bigger advantage is gained when you have an operation between two objects and it is not clear two which class the method should belong. (Explain why: it's not just that you don't have to make this decision; it affords more flexibility)

### Multiple-dispatch libraries

Multiple dispatch or multimethods in languages such as Dylan and Common Lisp (as CLOS) is older than the Julia language.
However, much of the motivation and design choices of current Python implementations come from Julia.

* [multimethod](https://github.com/coady/multimethod) I have not yet tried this library. It's stated goal is dispatch speed.
* [plum-dispatch](https://github.com/wesselb/plum) Probably the most feature-ful
    * Also exposes type conversion and promotion mechanisms modeled on Julia
    * Keyword-only args, separated by `*`, are supported. They do not enter into dispatch. This is similar to Julia
    * Supports @staticmethod, at least basic.
    * If no matching method is found at dispatch time, a `NotFoundLookupError` is raised. One could add a feature to plum to print closest matching methods, as Julia does. 
* multipledispatch
    * Cannot use default values for args. This should be a possible feature.
    * Lowest time overhead for dispatch in benchmarks (of multipledispatch, plum-dispatch, and fastcore)
* fastcore
    * If there is no matching method, a method may still be called, and also called incorrectly. It would be better to throw some kind of `MethodError`.
    * Not as featureful as others
    * Small. A single file < 200 LOC.

### Design issues

* How to organize documentation. Doc system is not built to accommodate MD

### Other considerations

#### Storing type-like information in various places

In qiskit, we sometimes distinguish "kinds" of objects by attributes; a flag or a string. Or by checking whether a method exists. This design complicates MD and makes it more difficult to apply broadly. I would be a good idea to move these things into the type system. The easiest way is to make another type rather than a use a flag. But, maybe there is also a way to use dispatch with a trait system.

Does a multiple-dispatch system turn Python into Julia? No. The blurred distinction between run time and compile time in Julia offers an advantage that is difficult to reproduce in Python (compilation itself is a big problem in Python). First, let's be more precise by what we mean by multiple dispatch.

#### Multiple dispatch vs. operator overloading
 MD is distinguished from function overloading in that the former is dynamic while the latter is static. Dispatch in the former is done on the dynamic type, in the latter it is done on the statically, lexically, analyzed type. Consider the code
```julia

function func(a::Animal)
    make_noise(a)
end
```
where we have three abstract types with the relation `Animal <: Thing`, `Machine <: Thing`, and another type `Dog <: Animal`. We might have methods
```julia
make_noise(m::Machine) = "crash"
make_noise(a::Animal) = "cry"
make_noise(dog::Dog) = "bark"
```
What happens when I call `func(dog)` ? In an operator-overloading language I get "cry", the static, lexically, deterimined type of `a`. In a MD language, dispatch is on the actual type of the object; I get "bark".

#### Run-time compilation and inference

But, an important advantage is present in both static languages and Julia that is not available in Python and CLOS. In Julia, when `func(dog)` is first called, the types of all expressions in the body are inferred if possible and code is compiled specially for the inferred types. In particular, although this is "dynamic dispatch", the method `make_noise` is devirtualized, and inlined if advantageous. This strategy  may be pursued to any depth (there are algorithms to determine when it is advantageous *not* to specialize). One thereby obtains advantages of both static and dynamic languages. 

* No diagonal dispatch. Some (all?) MD libraries' docs claim they do no support diagonal dispatch. I think the issue more broadly is that they do not support proper parametric types, in particular type parameters in the parameter lists. plum claims it has a method to get around lack of diagonal dispatch (using `Self`). But, I don't the problem worked around by `Self` is stated correctly. It is that `@dispatch` can't recognize the type of a class inside the definition of the class, because is net yet recognized by python. `Self` is in some sense a way to defer referring to the class by name.

* No universal, coherent type system.